### PR TITLE
Fix error in PHP 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ Templates are just PHP files—no mustaches and no frills.
 ```php
 // index.php
 (new µ)
-    ->cfg('views', __DIR__ . '/templates')
     ->get('/hello/(?<name>\w+)', function ($app, $params) {
-        echo $app->view('hello', [
+        echo $app->view(__DIR__ . '/templates', 'hello', [
             'greeting' => 'howdy',
             'name'     => $params['name'],
         ]);

--- a/examples/hello4.php
+++ b/examples/hello4.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+const VIEWS_DIR = __DIR__ . '/templates';
+
 (new µ)
-    ->cfg('views', __DIR__ . '/templates')
     ->get('/hello/(?<name>\w+)', function ($app, $params) {
-        echo $app->view('hello4', [
+        echo $app->view(VIEWS_DIR, 'hello4', [
             'greeting' => 'howdy',
             'name'     => $params['name'],
         ]);

--- a/mu.php
+++ b/mu.php
@@ -1,3 +1,3 @@
-<?php class µ{function __call($m,$a){$c=&$this->{$m.$a[0]};$c=$a[1]??(is_callable($c)?$c($this):$c);return isset($a[1])?
-$this:$c;}function run(){foreach($this as$x=>$f)preg_match("@$x@i","$_SERVER[REQUEST_METHOD]$_SERVER[REQUEST_URI]",$p)&&
-$f($this,$p);}function view($f,$d=[]){ob_start();extract($d);require"$this->cfgviews/$f.php";return ob_get_clean();}}#JL
+<?php class µ{var$Δ;function __call($m,$a){$c=&$this->Δ[$m.$a[0]];$c=$a[1]??(is_callable($c)?$c($this):$c);return($a[1]
+??0)?$this:$c;}function view($f,$d=[]){ob_start();extract($d);require"$f.php";return ob_get_clean();}function run(){#<3
+foreach($this->Δ as$x=>$f)preg_match("@$x@i","$_SERVER[REQUEST_METHOD]$_SERVER[REQUEST_URI]",$p)&&$f($this,$p);}}#ByJCL

--- a/mu.php
+++ b/mu.php
@@ -1,3 +1,3 @@
 <?php class µ{var$Δ;function __call($m,$a){$c=&$this->Δ[$m.$a[0]];$c=$a[1]??(is_callable($c)?$c($this):$c);return($a[1]
-??0)?$this:$c;}function view($f,$d=[]){ob_start();extract($d);require"$f.php";return ob_get_clean();}function run(){#<3
-foreach($this->Δ as$x=>$f)preg_match("@$x@i","$_SERVER[REQUEST_METHOD]$_SERVER[REQUEST_URI]",$p)&&$f($this,$p);}}#ByJCL
+??0)?$this:$c;}function view($d,$f,$s=[]){ob_start();extract($s);require"$d/$f.php";return ob_get_clean();}function run
+(){foreach($this->Δ as$x=>$f)preg_match("@$x@i","$_SERVER[REQUEST_METHOD]$_SERVER[REQUEST_URI]",$p)&&$f($this,$p);}}#JL

--- a/test.php
+++ b/test.php
@@ -54,7 +54,7 @@ $dir = sys_get_temp_dir().'/mu-view-test';
 $file = $dir.'/tpl.php';
 !is_dir($dir) and mkdir($dir);
 file_put_contents($file, '[<?=$foo?>]');
-$ñ = (new µ)->cfg('views', $dir)->view('tpl', ['foo' => 'bar']);
+$ñ = (new µ)->view($dir, 'tpl', ['foo' => 'bar']);
 unlink($file);
 rmdir($dir);
 assert($ñ === "[bar]");


### PR DESCRIPTION
Fixes #9 and is an alternative to #10. Since PHP 8.2 does not allow undeclared properties, we must declare one. Using `Δ`. 

I also explored using the `AllowDynamicProperties` attribute. Aside from it being way too long, is also would _require_ PHP 8.2.

This does remove the ability to do `->cfg('views', $directory)`, and instead adds a directory (`$d`) parameter to `->view()`. Ultimately, this is better anyway, as the previous implementation assumed the directory was set, and just errored when calling `->view()` when it wasn't.

New techniques used:
- Used oIder, shorter `var` instead of newer visibility modifiers (2+ chars saved).
- Replaced `isset($a[1])` with `($a[1]??0)` (2 chars saved).